### PR TITLE
fix(overwatch): audio bugs

### DIFF
--- a/resources/js/Pages/Overwatch/Live.vue
+++ b/resources/js/Pages/Overwatch/Live.vue
@@ -447,21 +447,25 @@ export default {
             this.pageStore.set("volume", this.volume);
         },
         destroyStream(full) {
-            clearInterval(this.interval);
+        clearInterval(this.interval);
 
-            if (full) {
-                this.source = false;
-                this.error = false;
-                this.isLoading = false;
+        const video = this.$refs.video;
+        if (video) {
+            video.pause();
+            video.src = '';
+            video.load();
+        }
 
-                this.updateChatRoom();
-            }
+        if (full) {
+            this.source = false;
+            this.error = false;
+            this.isLoading = false;
+            this.updateChatRoom();
+        }
 
-            if (!this.hls) return;
-
-            this.hls.destroy();
-
-            this.hls = false;
+        if (!this.hls) return;
+        this.hls.destroy();
+        this.hls = false;
         },
         updateChatRoom() {
             if (this.source) {
@@ -712,7 +716,7 @@ export default {
         }, 10000);
     },
     beforeUnmount() {
-        this.destroyStream();
+        this.destroyStream(true);
 
         clearInterval(this.timestampLoop);
     }

--- a/resources/js/Pages/Overwatch/Live.vue
+++ b/resources/js/Pages/Overwatch/Live.vue
@@ -447,25 +447,25 @@ export default {
             this.pageStore.set("volume", this.volume);
         },
         destroyStream(full) {
-        clearInterval(this.interval);
+            clearInterval(this.interval);
 
-        const video = this.$refs.video;
-        if (video) {
-            video.pause();
-            video.src = '';
-            video.load();
-        }
+            const video = this.$refs.video;
+            if (video) {
+                video.pause();
+                video.src = '';
+                video.load();
+            }
 
-        if (full) {
-            this.source = false;
-            this.error = false;
-            this.isLoading = false;
-            this.updateChatRoom();
-        }
+            if (full) {
+                this.source = false;
+                this.error = false;
+                this.isLoading = false;
+                this.updateChatRoom();
+            }
 
-        if (!this.hls) return;
-        this.hls.destroy();
-        this.hls = false;
+            if (!this.hls) return;
+            this.hls.destroy();
+            this.hls = false;
         },
         updateChatRoom() {
             if (this.source) {

--- a/resources/js/Pages/Overwatch/Live.vue
+++ b/resources/js/Pages/Overwatch/Live.vue
@@ -450,22 +450,28 @@ export default {
             clearInterval(this.interval);
 
             const video = this.$refs.video;
+
             if (video) {
                 video.pause();
-                video.src = '';
-                video.load();
             }
 
             if (full) {
                 this.source = false;
                 this.error = false;
                 this.isLoading = false;
+
                 this.updateChatRoom();
             }
 
-            if (!this.hls) return;
-            this.hls.destroy();
-            this.hls = false;
+            if (this.hls) {
+                this.hls.destroy();
+
+                this.hls = false;
+            }
+
+            if (video) {
+                video.remove();
+            }
         },
         updateChatRoom() {
             if (this.source) {


### PR DESCRIPTION
When leaving the live page, the video element kept playing buffered audio even after HLS.js was destroyed, because we were never actually telling the browser to stop. If you came back and started a new stream before it stopped, you'd end up with both playing at once. The fix pauses the video and clears its source on teardown, and also makes sure we pass true to destroyStream in beforeUnmount so everything is fully cleaned up when leaving the page.

:D