### PR TITLE
pages/Overwatch: fix Live.vue

### DIFF
--- a/resources/js/Pages/Overwatch/Live.vue
+++ b/resources/js/Pages/Overwatch/Live.vue
@@ -705,6 +705,9 @@ export default {
         window.removeEventListener("keyup", this.handleKeypress);
         window.removeEventListener("resize", this.setChatHeight);
         window.removeEventListener("fullscreenchange", this.updateFullscreen);
+
+        this.destroyStream(true);
+        clearInterval(this.timestampLoop);
     },
     mounted() {
         this.volume = this.pageStore.get("volume", 0.5);
@@ -720,11 +723,6 @@ export default {
         this.timestampLoop = setInterval(() => {
             this.timestamp = Math.floor(Date.now() / 1000);
         }, 10000);
-    },
-    beforeUnmount() {
-        this.destroyStream(true);
-
-        clearInterval(this.timestampLoop);
     }
 };
 </script>


### PR DESCRIPTION
I made oopsie... when navigating away from the page, the stream cleanup was never actually running because beforeUnmount is a vue 3 hook and the panel uses Vue 2, where the equivalent is destroyed. So the audio kept playing after leaving because nothing was telling it to stop. The fix just moves the cleanup into destroyed where it actually fires, and since that hook already existed for removing event listeners, it made sense to consolidate everything there rather than have two separate teardown hooks. It also randomly caused video to stop